### PR TITLE
Better way to identify if it should render or not

### DIFF
--- a/Plugins/BetterImageViewer/BetterImageViewer.plugin.js
+++ b/Plugins/BetterImageViewer/BetterImageViewer.plugin.js
@@ -1708,6 +1708,7 @@ module.exports = (() => {
                             __BIV_index: _this.props.__BIV_data ? _this.props.__BIV_data.images.findIndex(m => m.src === _this.props.src) : -1,
                             __BIV_isSearch: isSearch,
                             __BIV_settings: this.settings,
+                            __BIV_shouldRender: true,
                             className: ImageModalClasses.image,
                             shouldAnimate: true
                           },
@@ -1995,7 +1996,8 @@ module.exports = (() => {
         });
         Patcher.after(LazyImage.prototype, 'render', (_this, _, ret) => {
           if (!ret) return;
-          if (_this.props.__BIV_isVideo) return;
+          if (!_this.props.__BIV_shouldRender) return;
+          /*if (_this.props.className = "vz-addon-card-icon-image-wrapper") return;*/
           /* fix scaling issues for all images */
           if (!this.settings.chat.scale && _this.props.onZoom) return;
           const scale = window.innerWidth / (window.innerWidth * window.devicePixelRatio);
@@ -2018,7 +2020,7 @@ module.exports = (() => {
         });
         Patcher.after(WebpackModules.getByDisplayName('LazyVideo').prototype, 'render', (_, __, ret) => {
           if (!ret) return;
-          ret.props.__BIV_isVideo = true;
+          ret.props.__BIV_shouldRender = false;
         });
       }
 


### PR DESCRIPTION
I unlimited the zooming to if its not video. Before, the logic was: if I'm not in LazyVideo, so I don't render. The issue here is that it only injects into LazyImage, and so this causes some issues with plugins (and recently, Vizality), and most of time there isn't an LazyVideo to rescue the day. With this patch, now it will not render if LazyImage isn't in ImageModal

And yes the patch isn't limited to BIV only