### PR TITLE
Fix MessageLogger's Context Menu not showing in GroupDMs

### DIFF
--- a/Plugins/MessageLoggerV2/MessageLoggerV2.plugin.js
+++ b/Plugins/MessageLoggerV2/MessageLoggerV2.plugin.js
@@ -4719,7 +4719,7 @@ module.exports = class MessageLoggerV2 {
 
     this.unpatches.push(
       this.Patcher.after(
-        WebpackModules.find(({ default: defaul }) => defaul && defaul.displayName === 'GroupDMContextMenu'),
+        WebpackModules.find(({ default: defaul }) => defaul && defaul.displayName === 'GroupDMUserContextMenu'),
         'default',
         (_, [props], ret) => {
           const newItems = [];


### PR DESCRIPTION
Code is currently using `GroupDMContextMenu` but while it still logs activity, no option appears on the Context Menu, changing this to `GroupDMUserContextMenu` fixes this issue.